### PR TITLE
Updates on host side for MM5 SFCLAY_REV

### DIFF
--- a/scm/src/CCPP_typedefs.F90
+++ b/scm/src/CCPP_typedefs.F90
@@ -418,6 +418,7 @@ module CCPP_typedefs
 
     !-- NCAR MMM physics
     logical                             :: scm_force_flux                !< prescribe surface fluxes (not compute)  
+    logical                             :: isfflx                        !< compute surface fluxes in surface layer scheme
     real (kind=kind_phys), pointer      :: xland(:)           => null()
     real (kind=kind_phys), pointer      :: qcx(:,:)           => null()
     real (kind=kind_phys), pointer      :: qix(:,:)           => null()
@@ -426,12 +427,12 @@ module CCPP_typedefs
     real (kind=kind_phys), pointer      :: qgh(:)             => null()
     real (kind=kind_phys), pointer      :: qsfc(:)            => null()
     real (kind=kind_phys), pointer      :: gz1oz0(:)          => null()
+    real (kind=kind_phys), pointer      :: rv1d(:)            => null()
     real (kind=kind_phys), pointer      :: water_depth(:)     => null()
     real (kind=kind_phys)               :: shalwater_depth
     real (kind=kind_phys)               :: svp1
     real (kind=kind_phys)               :: svp2
     real (kind=kind_phys)               :: svp3
-    real (kind=kind_phys)               :: svpt0
     real (kind=kind_phys)               :: p1000mb 
     integer                             :: its
     integer                             :: ite
@@ -875,11 +876,13 @@ contains
         allocate (Interstitial%water_depth  (IM))
 
         Interstitial%scm_force_flux = .false. ! If MMM surface scheme used, fluxes are not prescribed 
+        Interstitial%isfflx         = .true. ! If MMM surface scheme used, fluxes are calculated 
     endif
     if (Model%do_ysu .or. Model%do_mmm_sfclayrev) then
        allocate (Interstitial%xland     (IM))
        allocate (Interstitial%hfx       (IM))
        allocate (Interstitial%qfx       (IM))
+       allocate (Interstitial%rv1d      (IM))
     endif
     if (Model%do_ysu) then
        allocate (Interstitial%wstar     (IM))
@@ -940,7 +943,7 @@ contains
     ! hardcoded value for calling GFDL MP in GFS_physics_driver.F90,
     ! which is set to .true.
     Interstitial%phys_hydrostatic = .true.
-
+    
     !
     ! CCPP suite simulator
     if (Model%do_ccpp_suite_sim) then
@@ -1512,7 +1515,6 @@ contains
        Interstitial%svp1            = clear_val
        Interstitial%svp2            = clear_val
        Interstitial%svp3            = clear_val
-       Interstitial%svpt0           = clear_val
        Interstitial%p1000mb         = clear_val
        Interstitial%its             = 0
        Interstitial%ite             = 0
@@ -1521,6 +1523,7 @@ contains
        Interstitial%xland       = 0
        Interstitial%hfx         = clear_val
        Interstitial%qfx         = clear_val
+       Interstitial%rv1d        = clear_val
     endif
     if (Model%do_ysu) then
        Interstitial%qcx         = clear_val
@@ -1609,12 +1612,10 @@ contains
     end if
     !
 
-    !
     ! CCPP suite simulator
     if (Model%do_ccpp_suite_sim) then
        Interstitial%active_phys_tend = clear_val
     endif
-
   end subroutine gfs_interstitial_phys_reset
 
 end module CCPP_typedefs

--- a/scm/src/CCPP_typedefs.meta
+++ b/scm/src/CCPP_typedefs.meta
@@ -2884,6 +2884,13 @@
   dimensions = ()
   type = logical
   active = (flag_for_mmm_sfclayrev_scheme)
+[isfflx]
+  standard_name = flag_to_compute_surface_heat_and_moisture_fluxes
+  long_name = flag to compute surface heat and moisture fluxes
+  units = flag
+  dimensions = ()
+  type = logical
+  active = (flag_for_mmm_sfclayrev_scheme)
 [xland]
   standard_name = sea_land_ice_mask_mmm
   long_name = sea/land/ice mask mmm
@@ -2956,6 +2963,14 @@
   type = real
   kind = kind_phys
   active = (flag_for_ysu_pbl_scheme .or. flag_for_mmm_sfclayrev_scheme)
+[rv1d]
+  standard_name = water_vapor_mixing_ratio_at_surface_adjacent_layer
+  long_name =  water vapor mixing ratio at surface adjacent layer
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mmm_sfclayrev_scheme)
 [qgh]
   standard_name = saturation_mixing_ratio_at_lowest_model_level
   long_name = saturation water vapor mixing ratio at lowest model level
@@ -3003,9 +3018,9 @@
   type = integer
   active = (flag_for_mmm_sfclayrev_scheme)
 [svp1]
-  standard_name = saturation_vapor_pressure_constant_1
-  long_name = constant for saturation vapor pressure calculation
-  units = k Pa
+  standard_name = saturation_pressure_at_triple_point_of_water_in_kPa
+  long_name = saturation pressure at triple point of water in kPa
+  units = kPa
   dimensions = ()
   type = real
   kind = kind_phys
@@ -3020,14 +3035,6 @@
   active = (flag_for_mmm_sfclayrev_scheme)
 [svp3]
   standard_name = saturation_vapor_pressure_constant_3
-  long_name = constant for saturation vapor pressure calculation
-  units = K
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  active = (flag_for_mmm_sfclayrev_scheme)
-[svpt0]
-  standard_name = saturation_vapor_pressure_constant_0
   long_name = constant for saturation vapor pressure calculation
   units = K
   dimensions = ()

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -1133,7 +1133,6 @@ module GFS_typedefs
     logical              :: ysu_topdown_pblmix !< flag for YSU: Option for YSU PBL mixing. 
     logical              :: ysu_timesplit      !< flag for YSU: Update internal-state after calling scheme?
     logical              :: do_mmm_sfclayrev   !< flag for MMM SFCLAY_REV
-    logical              :: isfflx             !< flag for MMM SFCLAY_REV: calculate surface fluxes
     logical              :: shalwater_z0       !< flag for MMM SFCLAY_REV: shallow water roughness scheme
     logical              :: do_mmm_ogwd        !< flag for MMM OGWD: flag for NCAR MMMs OGWD scheme.
     logical              :: mmm_ogwd_timesplit !< flag for MMM OGWD: Update internal-state after calling scheme?
@@ -3606,7 +3605,6 @@ module GFS_typedefs
     logical              :: ysu_topdown_pblmix  = .false.             !< flag for YSU: Option for YSU PBL mixing.
     logical              :: ysu_timesplit       = .false.             !< flag for YSU: Update internal-state after calling scheme?  
     logical              :: do_mmm_sfclayrev    = .false.             !< flag for MMM SFCLAY_REV
-    logical              :: isfflx              = .false.             !< flag for MMM SFCLAY_REV: computer surface fluxes
     logical              :: shalwater_z0        = .false.             !< flag for MMM SFCLAY_REV: shallow water roughness scheme
     logical              :: do_mmm_ogwd         = .false.             !< flag for MMM OGWD: flag for NCAR MMMs OGWD scheme.
     logical              :: mmm_ogwd_timesplit  = .false.             !< flag for MMM OGWD: Update internal-state after calling scheme?
@@ -4008,7 +4006,7 @@ module GFS_typedefs
                                h2o_phys, pdfcld, shcnvcw, redrag, hybedmf, satmedmf,        &
                                shinhong, do_ysu, do_ysu_cldliq, do_ysu_cldice, ysu_add_bep, &
                                ysu_topdown_pblmix, ysu_timesplit,                           &
-                               do_mmm_sfclayrev, isfflx, shalwater_z0,                      &
+                               do_mmm_sfclayrev, shalwater_z0,                              &
                                do_mmm_ogwd, mmm_ogwd_timesplit, mmm_ogwd_sfcflx,            &
                                mmm_ogwd_isftcflx, mmm_ogwd_iz0tlnd ,                        &
                                acm, dspheat, lheatstrg,                                     &
@@ -4884,7 +4882,6 @@ module GFS_typedefs
     Model%ysu_add_bep        = ysu_add_bep
     Model%ysu_timesplit      = ysu_timesplit
     Model%do_mmm_sfclayrev   = do_mmm_sfclayrev
-    Model%isfflx             = isfflx
     Model%shalwater_z0       = shalwater_z0
     Model%do_mmm_ogwd        = do_mmm_ogwd
     Model%mmm_ogwd_timesplit = mmm_ogwd_timesplit
@@ -6764,7 +6761,6 @@ module GFS_typedefs
       print *, ' ysu_add_bep       : ', Model%ysu_add_bep
       print *, ' ysu_timesplit     : ', Model%ysu_timesplit
       print *, ' do_mmm_sfclayrev  : ', Model%do_mmm_sfclayrev
-      print *, ' isfflx            : ', Model%isfflx    
       print *, ' shalwater_z0      : ', Model%shalwater_z0
       print *, ' do_mmm_ogwd       : ', Model%do_mmm_ogwd
       print *, ' mmm_ogwd_timesplit: ', Model%mmm_ogwd_timesplit

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -5145,12 +5145,6 @@
   units = flag
   dimensions = ()
   type = logical
-[isfflx]
-  standard_name = flag_to_compute_surface_heat_and_moisture_fluxes
-  long_name = flag to compute surface heat and moisture fluxes
-  units = flag
-  dimensions = ()
-  type = logical
 [shalwater_z0]
   standard_name = flag_for_shallow_water_roughness_scheme
   long_name = shallow water roughness scheme option


### PR DESCRIPTION
Updates were based on discussions with Laura, and suggestions from Jimy to handle flags of computing surface fluxes, and physical constants to calculate saturation vapor pressure of water (Bolton 1980).
In specific,

        modified:   ../../ccpp/physics
	modified:   CCPP_typedefs.F90
	modified:   CCPP_typedefs.meta
	modified:   GFS_typedefs.F90
	modified:   GFS_typedefs.meta